### PR TITLE
Add technical SEO foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,3 +81,8 @@ changing site-wide configuration.
 - ESLint: flat config, Astro + TypeScript ESLint + jsx-a11y rules
 - Unused variables prefixed with `_` are allowed; `@typescript-eslint/no-non-null-assertion` is off
 - `.editorconfig`: 2-space indent, LF line endings, UTF-8
+
+### SEO
+
+- when verifying SEO use the seo-audit skill
+- also read the google SEO article here https://developers.google.com/search/docs/fundamentals/seo-starter-guide?hl=en

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,6 +9,7 @@ import starlight from '@astrojs/starlight';
 import sitemap from '@astrojs/sitemap';
 import icon from 'astro-icon';
 import { buildDocsSidebar } from './src/utils/docs-sidebar.ts';
+import { shouldIncludeInSitemap } from './src/utils/seo-policy.ts';
 
 import { fileURLToPath } from 'url';
 
@@ -87,7 +88,9 @@ export default defineConfig({
       },
       plugins: [],
     }),
-    sitemap(),
+    sitemap({
+      filter: (page) => shouldIncludeInSitemap(new URL(page).pathname),
+    }),
     icon(),
     svelte(),
     sentry({

--- a/docs/superpowers/plans/2026-04-15-technical-seo-foundation.md
+++ b/docs/superpowers/plans/2026-04-15-technical-seo-foundation.md
@@ -1,0 +1,755 @@
+# Technical SEO Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `opensimgear.org` technically search-ready by default by enforcing index hygiene, centralizing metadata
+and schema generation, protecting stable section roots, and adding automated SEO guardrails.
+
+**Architecture:** Add a small SEO policy layer for indexability decisions, then extend the current title-only metadata
+flow into a shared metadata transformer that can set canonical, robots, Open Graph, Twitter, and schema tags from one
+place. Back it with route regression tests and repository-level guardrail tests so future content or slug changes cannot
+silently reintroduce broken section roots, placeholder indexable pages, or missing metadata.
+
+**Tech Stack:** Astro 6, Starlight, TypeScript, Vitest, static `public/` assets
+
+---
+
+### Task 1: Lock in section-root behavior for `/3rdparty/`
+
+**Files:**
+
+- Modify: `src/tests/docs/sidebar-config.test.ts`
+- Test: `src/tests/docs/sidebar-config.test.ts`
+
+- [ ] **Step 1: Update failing test to assert the current `/3rdparty/` root link instead of the old
+      `/3rdparty/overview/` path**
+
+```ts
+it('uses configured basePath for third-party docs slugs', () => {
+  const sidebar = buildDocsSidebar({ docsRoot: thirdPartyRoot, basePath: '/3rdparty' });
+
+  expect(sidebar).toContainEqual({
+    label: 'Overview',
+    link: '/3rdparty/',
+  });
+
+  const beltTensionerGroup = sidebar.find((item) => item.label === 'Belt Tensioner');
+
+  if (!beltTensionerGroup || !('items' in beltTensionerGroup)) {
+    throw new Error('Expected Belt Tensioner to be a sidebar group');
+  }
+
+  expect(beltTensionerGroup.items).toContainEqual({
+    label: 'Flag Ghost Belt Tensioner',
+    link: '/3rdparty/belt-tensioner/flagghost/',
+  });
+});
+```
+
+- [ ] **Step 2: Add a second regression test that proves top-level `index.md` always maps to the basePath root**
+
+```ts
+it('maps a top-level index file to the base path root', () => {
+  const fixtureRoot = createDocsFixture({
+    'index.md': `---
+title: Overview
+sidebar:
+  order: 0
+---
+`,
+    'belt-tensioner/index.md': `---
+title: Belt Tensioner Overview
+sidebar:
+  label: Belt Tensioner
+  order: 1
+---
+`,
+  });
+
+  const sidebar = buildDocsSidebar({ docsRoot: fixtureRoot, basePath: '/3rdparty' });
+
+  expect(sidebar).toContainEqual({
+    label: 'Overview',
+    link: '/3rdparty/',
+  });
+});
+```
+
+- [ ] **Step 3: Run the focused docs sidebar test file to confirm the regression is covered**
+
+Run: `pnpm test src/tests/docs/sidebar-config.test.ts`
+
+Expected: PASS, with the updated `/3rdparty/` expectations and no remaining references to `/3rdparty/overview/`
+
+- [ ] **Step 4: Commit the route regression coverage**
+
+```bash
+git add src/tests/docs/sidebar-config.test.ts
+git commit -m "test: cover third-party section root"
+```
+
+### Task 2: Add SEO policy tests for indexable versus `noindex` pages
+
+**Files:**
+
+- Create: `src/tests/docs/seo-policy.test.ts`
+- Create: `src/utils/seo-policy.ts`
+- Test: `src/tests/docs/seo-policy.test.ts`
+
+- [ ] **Step 1: Write failing tests for canonical URL generation, default preview image generation, and
+      placeholder-route `noindex` policy**
+
+```ts
+import { describe, expect, it } from 'vitest';
+
+import { buildCanonicalUrl, buildDefaultSocialImageUrl, getSeoPolicy } from '../../utils/seo-policy';
+
+describe('getSeoPolicy', () => {
+  it('marks known placeholder gear routes as noindex', () => {
+    expect(getSeoPolicy('/gear/')).toEqual({ index: false, follow: true });
+    expect(getSeoPolicy('/gear/hand-brake/')).toEqual({ index: false, follow: true });
+  });
+
+  it('keeps published docs routes indexable by default', () => {
+    expect(getSeoPolicy('/docs/components/')).toEqual({ index: true, follow: true });
+  });
+});
+
+describe('buildCanonicalUrl', () => {
+  it('builds an absolute canonical URL from the configured site origin and pathname', () => {
+    expect(buildCanonicalUrl('https://www.opensimgear.org', '/3rdparty/')).toBe(
+      'https://www.opensimgear.org/3rdparty/'
+    );
+  });
+});
+
+describe('buildDefaultSocialImageUrl', () => {
+  it('builds an absolute social preview image URL', () => {
+    expect(buildDefaultSocialImageUrl('https://www.opensimgear.org')).toBe(
+      'https://www.opensimgear.org/social-preview-default.svg'
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test file to verify RED because the SEO policy module does not exist yet**
+
+Run: `pnpm test src/tests/docs/seo-policy.test.ts`
+
+Expected: FAIL with a module resolution error for `../../utils/seo-policy`
+
+- [ ] **Step 3: Add the minimal SEO policy implementation to satisfy the tests**
+
+```ts
+type SeoPolicy = {
+  index: boolean;
+  follow: boolean;
+};
+
+const NOINDEX_PREFIXES = ['/gear/'];
+
+export function getSeoPolicy(pathname: string): SeoPolicy {
+  const normalizedPath = pathname.endsWith('/') ? pathname : `${pathname}/`;
+  const shouldNoindex = NOINDEX_PREFIXES.some((prefix) => normalizedPath.startsWith(prefix));
+
+  return {
+    index: !shouldNoindex,
+    follow: true,
+  };
+}
+
+export function buildCanonicalUrl(site: string, pathname: string) {
+  return new URL(pathname, site).toString();
+}
+
+export function buildDefaultSocialImageUrl(site: string) {
+  return new URL('/social-preview-default.svg', site).toString();
+}
+```
+
+- [ ] **Step 4: Re-run the focused SEO policy test file to verify GREEN**
+
+Run: `pnpm test src/tests/docs/seo-policy.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit the SEO policy module and tests**
+
+```bash
+git add src/utils/seo-policy.ts src/tests/docs/seo-policy.test.ts
+git commit -m "feat: add seo index policy"
+```
+
+### Task 3: Expand the head logic into a shared metadata transformer
+
+**Files:**
+
+- Create: `src/tests/docs/seo-meta.test.ts`
+- Create: `src/utils/seo-meta.ts`
+- Modify: `src/components/overrides/Head.astro`
+- Test: `src/tests/docs/seo-meta.test.ts`
+
+- [ ] **Step 1: Write failing tests for canonical, robots, Open Graph, and Twitter defaults**
+
+```ts
+import { describe, expect, it } from 'vitest';
+
+import type { StarlightRouteData } from '@astrojs/starlight/route-data';
+
+import { applySeoMetadata } from '../../utils/seo-meta';
+
+type HeadEntry = StarlightRouteData['head'][number];
+
+const baseHead: StarlightRouteData['head'] = [
+  { tag: 'title', content: 'Overview | OpenSimGear' },
+  { tag: 'meta', attrs: { name: 'description', content: 'Existing description' } },
+  { tag: 'meta', attrs: { property: 'og:title', content: 'Overview | OpenSimGear' } },
+  { tag: 'meta', attrs: { name: 'twitter:title', content: 'Overview | OpenSimGear' } },
+];
+
+function findEntry(head: StarlightRouteData['head'], tag: string, attrName: string, attrValue: string) {
+  return head.find((entry) => entry.tag === tag && entry.attrs?.[attrName] === attrValue);
+}
+
+describe('applySeoMetadata', () => {
+  it('adds canonical, robots, og:image, and twitter:image defaults', () => {
+    const head = applySeoMetadata({
+      head: baseHead,
+      pathname: '/docs/components/',
+      site: 'https://www.opensimgear.org',
+      seoTitle: 'Components Overview | OpenSimGear',
+      description: 'Browse the main hardware categories used in sim racing and flight simulation.',
+      robots: { index: true, follow: true },
+      defaultImageUrl: 'https://www.opensimgear.org/social-preview-default.svg',
+    });
+
+    expect(findEntry(head, 'link', 'rel', 'canonical')).toEqual({
+      tag: 'link',
+      attrs: { rel: 'canonical', href: 'https://www.opensimgear.org/docs/components/' },
+    });
+
+    expect(findEntry(head, 'meta', 'name', 'robots')).toEqual({
+      tag: 'meta',
+      attrs: { name: 'robots', content: 'index, follow' },
+    });
+
+    expect(findEntry(head, 'meta', 'property', 'og:image')).toEqual({
+      tag: 'meta',
+      attrs: { property: 'og:image', content: 'https://www.opensimgear.org/social-preview-default.svg' },
+    });
+
+    expect(findEntry(head, 'meta', 'name', 'twitter:image')).toEqual({
+      tag: 'meta',
+      attrs: { name: 'twitter:image', content: 'https://www.opensimgear.org/social-preview-default.svg' },
+    });
+  });
+
+  it('writes noindex, follow for placeholder pages', () => {
+    const head = applySeoMetadata({
+      head: baseHead,
+      pathname: '/gear/',
+      site: 'https://www.opensimgear.org',
+      seoTitle: 'Gear Overview | OpenSimGear',
+      description: 'Browse open-source sim racing and flight simulation gear designs.',
+      robots: { index: false, follow: true },
+      defaultImageUrl: 'https://www.opensimgear.org/social-preview-default.svg',
+    });
+
+    expect(findEntry(head, 'meta', 'name', 'robots')).toEqual({
+      tag: 'meta',
+      attrs: { name: 'robots', content: 'noindex, follow' },
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused metadata test file to verify RED because the shared metadata module does not exist yet**
+
+Run: `pnpm test src/tests/docs/seo-meta.test.ts`
+
+Expected: FAIL with a module resolution error for `../../utils/seo-meta`
+
+- [ ] **Step 3: Implement the shared metadata transformer with tag upsert helpers**
+
+```ts
+import type { StarlightRouteData } from '@astrojs/starlight/route-data';
+
+import { buildCanonicalUrl } from './seo-policy';
+
+type HeadEntry = StarlightRouteData['head'][number];
+
+type ApplySeoMetadataOptions = {
+  head: StarlightRouteData['head'];
+  pathname: string;
+  site: string;
+  seoTitle: string;
+  description: string;
+  robots: { index: boolean; follow: boolean };
+  defaultImageUrl: string;
+};
+
+function upsertMeta(
+  head: StarlightRouteData['head'],
+  attrName: 'name' | 'property',
+  attrValue: string,
+  content: string
+) {
+  const existing = head.find((entry) => entry.tag === 'meta' && entry.attrs?.[attrName] === attrValue);
+
+  if (existing) {
+    existing.attrs = { ...existing.attrs, content };
+    return;
+  }
+
+  head.push({
+    tag: 'meta',
+    attrs: { [attrName]: attrValue, content },
+  } as HeadEntry);
+}
+
+function upsertCanonical(head: StarlightRouteData['head'], href: string) {
+  const existing = head.find((entry) => entry.tag === 'link' && entry.attrs?.rel === 'canonical');
+
+  if (existing) {
+    existing.attrs = { ...existing.attrs, href };
+    return;
+  }
+
+  head.push({ tag: 'link', attrs: { rel: 'canonical', href } } as HeadEntry);
+}
+
+export function applySeoMetadata({
+  head,
+  pathname,
+  site,
+  seoTitle,
+  description,
+  robots,
+  defaultImageUrl,
+}: ApplySeoMetadataOptions) {
+  const nextHead = [...head];
+  const robotsContent = `${robots.index ? 'index' : 'noindex'}, ${robots.follow ? 'follow' : 'nofollow'}`;
+  const canonical = buildCanonicalUrl(site, pathname);
+
+  upsertCanonical(nextHead, canonical);
+  upsertMeta(nextHead, 'name', 'description', description);
+  upsertMeta(nextHead, 'name', 'robots', robotsContent);
+  upsertMeta(nextHead, 'property', 'og:title', seoTitle);
+  upsertMeta(nextHead, 'property', 'og:description', description);
+  upsertMeta(nextHead, 'property', 'og:url', canonical);
+  upsertMeta(nextHead, 'property', 'og:image', defaultImageUrl);
+  upsertMeta(nextHead, 'name', 'twitter:title', seoTitle);
+  upsertMeta(nextHead, 'name', 'twitter:description', description);
+  upsertMeta(nextHead, 'name', 'twitter:card', 'summary_large_image');
+  upsertMeta(nextHead, 'name', 'twitter:image', defaultImageUrl);
+
+  return nextHead;
+}
+```
+
+- [ ] **Step 4: Wire the new metadata transformer into the head override**
+
+```astro
+---
+import Default from '@astrojs/starlight/components/Head.astro';
+import GoogleAnalytics from '~/components/util/GoogleAnalytics.astro';
+import { config } from '~/config';
+import { applySeoMetadata } from '~/utils/seo-meta';
+import { buildSeoPageTitle, replaceSeoTitleTags } from '~/utils/page-title';
+import { buildDefaultSocialImageUrl, getSeoPolicy } from '~/utils/seo-policy';
+
+const { starlightRoute } = Astro.locals;
+const seoTitle = buildSeoPageTitle({
+  pageTitle: starlightRoute.entry.data.title,
+  siteTitle: starlightRoute.siteTitle,
+  pathname: Astro.url.pathname,
+  sidebar: starlightRoute.sidebar,
+});
+const seoDescription = starlightRoute.entry.data.description ?? '';
+const seoRobots = getSeoPolicy(Astro.url.pathname);
+
+starlightRoute.head = replaceSeoTitleTags(starlightRoute.head, seoTitle);
+starlightRoute.head = applySeoMetadata({
+  head: starlightRoute.head,
+  pathname: Astro.url.pathname,
+  site: config.site,
+  seoTitle,
+  description: seoDescription,
+  robots: seoRobots,
+  defaultImageUrl: buildDefaultSocialImageUrl(config.site),
+});
+---
+```
+
+- [ ] **Step 5: Re-run the focused metadata test file to verify GREEN**
+
+Run: `pnpm test src/tests/docs/seo-meta.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 6: Commit the shared metadata transformer**
+
+```bash
+git add src/utils/seo-meta.ts src/components/overrides/Head.astro src/tests/docs/seo-meta.test.ts
+git commit -m "feat: centralize seo metadata tags"
+```
+
+### Task 4: Add structured data helpers for homepage and breadcrumb-capable docs pages
+
+**Files:**
+
+- Create: `src/tests/docs/structured-data.test.ts`
+- Create: `src/utils/structured-data.ts`
+- Modify: `src/components/overrides/Head.astro`
+- Test: `src/tests/docs/structured-data.test.ts`
+
+- [ ] **Step 1: Write failing tests for homepage organization and website schema plus breadcrumb schema generation**
+
+```ts
+import { describe, expect, it } from 'vitest';
+
+import { buildBreadcrumbSchema, buildSiteSchemas } from '../../utils/structured-data';
+
+describe('buildSiteSchemas', () => {
+  it('builds organization and website schema for the homepage', () => {
+    const scripts = buildSiteSchemas({
+      site: 'https://www.opensimgear.org',
+      title: 'OpenSimGear',
+    });
+
+    expect(scripts).toHaveLength(2);
+    expect(scripts[0]).toContain('Organization');
+    expect(scripts[1]).toContain('WebSite');
+  });
+});
+
+describe('buildBreadcrumbSchema', () => {
+  it('builds breadcrumb schema when page and parent labels are known', () => {
+    expect(
+      buildBreadcrumbSchema({
+        site: 'https://www.opensimgear.org',
+        pathname: '/docs/components/',
+        labels: ['Docs', 'Components', 'Overview'],
+      })
+    ).toContain('BreadcrumbList');
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused structured-data test file to verify RED because the helper module does not exist yet**
+
+Run: `pnpm test src/tests/docs/structured-data.test.ts`
+
+Expected: FAIL with a module resolution error for `../../utils/structured-data`
+
+- [ ] **Step 3: Implement structured-data helpers that return JSON-LD strings**
+
+```ts
+type BreadcrumbSchemaOptions = {
+  site: string;
+  pathname: string;
+  labels: string[];
+};
+
+type SiteSchemaOptions = {
+  site: string;
+  title: string;
+};
+
+export function buildSiteSchemas({ site, title }: SiteSchemaOptions) {
+  return [
+    JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'Organization',
+      name: title,
+      url: site,
+    }),
+    JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'WebSite',
+      name: title,
+      url: site,
+    }),
+  ];
+}
+
+export function buildBreadcrumbSchema({ site, pathname, labels }: BreadcrumbSchemaOptions) {
+  if (labels.length < 2) {
+    return undefined;
+  }
+
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: labels.map((name, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name,
+      item: index === labels.length - 1 ? new URL(pathname, site).toString() : undefined,
+    })),
+  });
+}
+```
+
+- [ ] **Step 4: Emit the JSON-LD scripts from the head override for homepage and breadcrumb-capable docs pages**
+
+```astro
+---
+import { buildBreadcrumbSchema, buildSiteSchemas } from '~/utils/structured-data';
+
+const breadcrumbLabels = [
+  starlightRoute.sidebar.find((entry) => entry.type === 'group' && Astro.url.pathname.startsWith('/docs/'))?.label,
+  starlightRoute.entry.data.title,
+].filter(Boolean) as string[];
+
+const siteSchemas =
+  Astro.url.pathname === '/' ? buildSiteSchemas({ site: config.site, title: starlightRoute.siteTitle }) : [];
+const breadcrumbSchema = Astro.url.pathname.startsWith('/docs/')
+  ? buildBreadcrumbSchema({
+      site: config.site,
+      pathname: Astro.url.pathname,
+      labels: breadcrumbLabels,
+    })
+  : undefined;
+---
+
+<Default {...Astro.props}><slot /></Default>
+{siteSchemas.map((schema) => <script type="application/ld+json" set:html={schema} />)}
+{breadcrumbSchema && <script type="application/ld+json" set:html={breadcrumbSchema} />}
+{import.meta.env.PROD && <GoogleAnalytics />}
+```
+
+- [ ] **Step 5: Re-run the focused structured-data test file to verify GREEN**
+
+Run: `pnpm test src/tests/docs/structured-data.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 6: Commit the structured-data layer**
+
+```bash
+git add src/utils/structured-data.ts src/components/overrides/Head.astro src/tests/docs/structured-data.test.ts
+git commit -m "feat: add seo structured data"
+```
+
+### Task 5: Add a default social preview asset and connect it to production metadata
+
+**Files:**
+
+- Create: `public/social-preview-default.svg`
+- Modify: `src/tests/docs/seo-policy.test.ts`
+- Test: `src/tests/docs/seo-policy.test.ts`
+
+- [ ] **Step 1: Add a simple branded SVG preview asset that can ship immediately**
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">OpenSimGear Social Preview</title>
+  <desc id="desc">OpenSimGear open-source sim racing and flight simulation hardware.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#1e293b" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" rx="32" />
+  <g fill="#e2e8f0">
+    <text x="84" y="228" font-size="86" font-family="system-ui, sans-serif" font-weight="700">OpenSimGear</text>
+    <text x="84" y="314" font-size="34" font-family="system-ui, sans-serif">Open-source sim racing and flight simulation hardware</text>
+    <text x="84" y="404" font-size="28" font-family="system-ui, sans-serif" fill="#94a3b8">Docs, calculators, DIY reference, and community-built gear</text>
+  </g>
+</svg>
+```
+
+- [ ] **Step 2: Extend the SEO policy test to assert the default asset path exists in generated URLs**
+
+```ts
+it('uses the default social preview asset path', () => {
+  expect(buildDefaultSocialImageUrl('https://www.opensimgear.org')).toBe(
+    'https://www.opensimgear.org/social-preview-default.svg'
+  );
+});
+```
+
+- [ ] **Step 3: Run the focused SEO policy test file to confirm the asset path still matches production metadata
+      behavior**
+
+Run: `pnpm test src/tests/docs/seo-policy.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 4: Commit the default social preview asset**
+
+```bash
+git add public/social-preview-default.svg src/tests/docs/seo-policy.test.ts
+git commit -m "feat: add default social preview asset"
+```
+
+### Task 6: Add repository guardrails for empty descriptions and placeholder indexable pages
+
+**Files:**
+
+- Create: `src/tests/docs/seo-guardrails.test.ts`
+- Create: `src/utils/docs-frontmatter.ts`
+- Modify: `src/utils/seo-policy.ts`
+- Test: `src/tests/docs/seo-guardrails.test.ts`
+
+- [ ] **Step 1: Write failing repository-level tests that scan docs content and reject indexable placeholder pages**
+
+```ts
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { parseDocFrontmatter } from '../../utils/docs-frontmatter';
+import { getSeoPolicy } from '../../utils/seo-policy';
+
+const docsRoot = path.resolve(process.cwd(), 'src/content/docs');
+
+function collectDocFiles(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const resolved = path.join(dir, entry.name);
+    if (entry.isDirectory()) return collectDocFiles(resolved);
+    return /\.mdx?$/.test(entry.name) ? [resolved] : [];
+  });
+}
+
+describe('SEO content guardrails', () => {
+  it('requires every indexable doc page to have a non-empty description', () => {
+    const offenders = collectDocFiles(docsRoot)
+      .map((filePath) => ({ filePath, parsed: parseDocFrontmatter(filePath) }))
+      .filter(({ parsed }) => getSeoPolicy(parsed.pathname).index)
+      .filter(({ parsed }) => parsed.description.trim().length === 0)
+      .map(({ filePath }) => filePath);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('rejects placeholder copy on indexable doc pages', () => {
+    const offenders = collectDocFiles(docsRoot)
+      .map((filePath) => ({ filePath, parsed: parseDocFrontmatter(filePath) }))
+      .filter(({ parsed }) => getSeoPolicy(parsed.pathname).index)
+      .filter(({ parsed }) => /coming soon/i.test(parsed.body))
+      .map(({ filePath }) => filePath);
+
+    expect(offenders).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the guardrail test file to verify RED against the current repository state**
+
+Run: `pnpm test src/tests/docs/seo-guardrails.test.ts`
+
+Expected: FAIL, initially surfacing the current placeholder gear pages as indexable offenders
+
+- [ ] **Step 3: Add a small frontmatter parser helper and teach the SEO policy to noindex the known placeholder gear
+      section**
+
+```ts
+// src/utils/docs-frontmatter.ts
+import fs from 'node:fs';
+import path from 'node:path';
+
+function toPathname(filePath: string) {
+  const relativePath = path.relative(path.resolve(process.cwd(), 'src/content/docs'), filePath).replace(/\\/g, '/');
+  const withoutExtension = relativePath.replace(/\.mdx?$/, '');
+  const slug = withoutExtension === 'index' ? '' : withoutExtension.replace(/\/index$/, '');
+  return slug ? `/${slug}/` : '/';
+}
+
+export function parseDocFrontmatter(filePath: string) {
+  const source = fs.readFileSync(filePath, 'utf8');
+  const match = source.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+
+  if (!match) {
+    throw new Error(`Missing frontmatter in ${filePath}`);
+  }
+
+  const frontmatter = match[1];
+  const body = match[2];
+  const singleLineDescription = frontmatter.match(/^description:\s*(.+)$/m)?.[1]?.trim();
+  const multilineDescription = frontmatter.match(/^description:\s*\n((?:[ \t].*\n?)*)/m)?.[1] ?? '';
+  const description =
+    singleLineDescription && singleLineDescription !== ''
+      ? singleLineDescription
+      : multilineDescription.replace(/^[ \t]+/gm, '').trim();
+
+  return {
+    pathname: toPathname(filePath),
+    description,
+    body,
+  };
+}
+
+// src/utils/seo-policy.ts
+const NOINDEX_PREFIXES = ['/gear/'];
+```
+
+- [ ] **Step 4: Re-run the guardrail test file to verify GREEN after the placeholder routes become `noindex` and
+      multiline descriptions parse correctly**
+
+Run: `pnpm test src/tests/docs/seo-guardrails.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit the repository guardrails**
+
+```bash
+git add src/utils/docs-frontmatter.ts src/utils/seo-policy.ts src/tests/docs/seo-guardrails.test.ts
+git commit -m "test: add seo content guardrails"
+```
+
+### Task 7: Run verification suite and fix any integration fallout
+
+**Files:**
+
+- Modify: `src/components/overrides/Head.astro`
+- Modify: `src/utils/seo-meta.ts`
+- Modify: `src/utils/structured-data.ts`
+- Modify: `src/utils/seo-policy.ts`
+- Modify: `src/tests/docs/sidebar-config.test.ts`
+- Modify: `src/tests/docs/seo-policy.test.ts`
+- Modify: `src/tests/docs/seo-meta.test.ts`
+- Modify: `src/tests/docs/structured-data.test.ts`
+- Modify: `src/tests/docs/seo-guardrails.test.ts`
+
+- [ ] **Step 1: Run all docs SEO-focused tests together**
+
+Run:
+`pnpm test src/tests/docs/sidebar-config.test.ts src/tests/docs/page-title.test.ts src/tests/docs/seo-policy.test.ts src/tests/docs/seo-meta.test.ts src/tests/docs/structured-data.test.ts src/tests/docs/seo-guardrails.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 2: Run the full project test suite to catch unrelated fallout**
+
+Run: `pnpm test`
+
+Expected: PASS
+
+- [ ] **Step 3: Run the production build to verify Astro, Starlight, sitemap, and head generation still succeed**
+
+Run: `pnpm build`
+
+Expected: PASS, with the usual third-party package warnings but no build failures
+
+- [ ] **Step 4: If any verification fails, make the smallest fix in the affected SEO module and re-run only the failing
+      command before returning to the full verification sequence**
+
+```ts
+// Example minimal fix pattern in src/utils/seo-meta.ts
+if (description.trim().length > 0) {
+  upsertMeta(nextHead, 'name', 'description', description);
+  upsertMeta(nextHead, 'property', 'og:description', description);
+  upsertMeta(nextHead, 'name', 'twitter:description', description);
+}
+```
+
+- [ ] **Step 5: Commit the verified technical SEO foundation**
+
+```bash
+git add src/components/overrides/Head.astro src/utils/seo-policy.ts src/utils/seo-meta.ts src/utils/structured-data.ts src/utils/docs-frontmatter.ts public/social-preview-default.svg src/tests/docs/sidebar-config.test.ts src/tests/docs/seo-policy.test.ts src/tests/docs/seo-meta.test.ts src/tests/docs/structured-data.test.ts src/tests/docs/seo-guardrails.test.ts
+git commit -m "feat: add technical seo foundation"
+```

--- a/docs/superpowers/specs/2026-04-15-technical-seo-foundation-design.md
+++ b/docs/superpowers/specs/2026-04-15-technical-seo-foundation-design.md
@@ -1,0 +1,437 @@
+# Technical SEO Foundation Design
+
+## Goal
+
+Make `opensimgear.org` technically search-ready by default.
+
+This work should ensure only worthwhile pages are indexable, centralize metadata and structured-data behavior, and add
+automated guardrails so SEO regressions are caught during normal development.
+
+## Why This Exists
+
+The site already has sound crawl basics:
+
+- `robots.txt` allows crawl and points at the sitemap
+- sitemap generation is enabled and working
+- canonical domain and HTTPS behavior are consistent
+- recent title work improved one part of metadata generation
+
+However, the site still has several structural SEO gaps:
+
+- thin and placeholder pages remain indexable
+- many content files still have missing or weak descriptions
+- there is no shared schema layer
+- there is no default social preview image system
+- internal discovery does not fully match all published routes
+- SEO regressions can slip in during routine content changes
+
+This design defines technical foundation work only. It does not include the broader content strategy or editorial
+rewrite program.
+
+## Product Outcomes
+
+### Primary outcome
+
+Search engines should index only pages that are worth ranking, and every indexable page should emit strong technical SEO
+signals by default.
+
+### Business outcomes
+
+- improve discoverability for docs and calculators
+- improve trust through cleaner search snippets and link previews
+- reduce crawl waste on placeholders and low-value pages
+- reduce SEO regressions as docs content grows
+
+### User outcomes
+
+- shared links should render better previews
+- important section roots should resolve consistently
+- search snippets should better match page intent
+- users should be able to discover important sections through navigation and internal links
+
+## Success Criteria
+
+The implementation should satisfy these measurable outcomes:
+
+- zero intentionally indexable placeholder pages
+- zero empty descriptions on indexable content
+- shared metadata generation covers title, description, canonical, robots, Open Graph, and Twitter tags
+- default social preview image exists for pages that do not define one explicitly
+- homepage emits organization and website schema
+- breadcrumb-capable documentation pages emit breadcrumb schema when page context is available
+- sitemap contains only canonical, indexable URLs
+- automated tests cover route stability for section roots such as `/3rdparty/`
+
+## Scope
+
+### In scope
+
+- index versus `noindex` policy
+- sitemap inclusion rules
+- central metadata generation
+- structured data defaults
+- default Open Graph and Twitter preview image behavior
+- section-root stability and redirect behavior where needed
+- navigation and internal discovery improvements for important sections
+- automated SEO regression guardrails
+
+### Out of scope
+
+- keyword research and SERP strategy
+- bulk content rewriting
+- backlink or off-site SEO work
+- analytics dashboards and reporting workflows
+- full editorial content program
+
+## Current Context
+
+This site uses Astro and Starlight.
+
+Relevant current implementation points:
+
+- `astro.config.mjs` configures the canonical site URL and sitemap generation
+- `src/components/overrides/Head.astro` overrides Starlight head rendering
+- `src/utils/page-title.ts` already contains breadcrumb-aware title logic
+- documentation content lives under `src/content/docs/`
+- generated section navigation currently depends on `buildDocsSidebar()` for some content groups
+
+Recent work already improved metadata titles, especially for generic page names such as `Overview`. This design should
+build on that foundation rather than replacing it with a separate parallel mechanism.
+
+## Problem Statement
+
+The biggest current SEO weakness is not crawlability. It is index hygiene and metadata completeness.
+
+The site can be crawled and built correctly, but search engines are still exposed to pages that are too thin to rank
+well, while richer metadata and structured data are not emitted consistently enough to support strong snippets and link
+previews.
+
+Examples from the current audit:
+
+- multiple content files contain empty `description:` frontmatter
+- several published pages are effectively placeholders or near-placeholders
+- no schema implementation was detected in rendered pages
+- no `og:image` or `twitter:image` default system was detected
+- some section roots require regression protection so future content moves do not silently break live routes
+
+## Users and Stakeholders
+
+### Search engines and social crawlers
+
+These systems consume metadata, canonical signals, robots directives, structured data, and route structure.
+
+### End users
+
+Visitors arriving from search results, shared links, and docs navigation should land on pages with better preview
+quality and fewer low-value dead ends.
+
+### Maintainers and content authors
+
+Contributors should benefit from safe defaults and guardrails without being forced to hand-author complex metadata for
+every routine page.
+
+## Requirements
+
+### Requirement 1: Index hygiene policy
+
+The system must explicitly define which page types are indexable.
+
+The implementation should support these outcomes:
+
+- pages that are truly ready for search should remain indexable
+- placeholder, near-empty, or explicitly work-in-progress pages should be `noindex` or excluded from the sitemap until
+  ready
+- indexability decisions should be deterministic and testable
+- maintainers should not need to remember manual cleanup rules page-by-page
+
+This requirement exists because build success alone is not enough. A page can build correctly and still be poor search
+inventory.
+
+### Requirement 2: Shared metadata platform
+
+The site should generate metadata through one shared path instead of piecemeal behavior.
+
+This shared metadata system should emit, at minimum:
+
+- HTML `<title>`
+- `meta name="description"`
+- canonical URL link tag
+- robots directives
+- `og:title`
+- `og:description`
+- `og:url`
+- `og:image`
+- `twitter:title`
+- `twitter:description`
+- `twitter:card`
+- `twitter:image`
+
+The current breadcrumb-aware title helper should become one piece of this broader metadata platform rather than staying
+an isolated solution.
+
+### Requirement 3: Safe fallback behavior
+
+Metadata generation must fail safe when page context is incomplete.
+
+Examples:
+
+- if breadcrumb context cannot be resolved, use safe default title behavior
+- if a page lacks custom social media assets, use a default preview image
+- if schema requirements are incomplete, do not emit partial or misleading schema
+
+This prevents brittle logic and keeps metadata output predictable across all route types.
+
+### Requirement 4: Structured data layer
+
+The site should emit useful JSON-LD only when the page context supports it.
+
+Minimum schema targets for this phase:
+
+- homepage emits organization schema
+- homepage emits website schema
+- docs pages with reliable breadcrumb context emit breadcrumb schema
+
+Schema should be omitted rather than guessed when required fields are missing.
+
+### Requirement 5: Discovery and route stability
+
+Important section roots and canonical routes must stay stable and discoverable.
+
+This includes:
+
+- keeping valid section roots such as `/3rdparty/` resolvable
+- adding regression protection so content moves or file renames do not silently break those roots later
+- ensuring internal navigation and links expose important crawl targets
+- keeping sitemap URLs aligned with canonical live routes
+
+This design does not assume every section root needs a redirect. It assumes every intended public root should be tested
+and preserved intentionally.
+
+### Requirement 6: SEO guardrails
+
+The build and test layer should catch common SEO regressions before deployment.
+
+Guardrails for this phase should cover:
+
+- empty descriptions on indexable pages
+- placeholder text on indexable pages
+- missing default metadata tags
+- sitemap inclusion mistakes
+- section-root route regressions
+
+The purpose is not to block all work-in-progress content. The purpose is to block accidental publication of low-quality
+search inventory.
+
+## Non-Functional Requirements
+
+- preserve existing Astro and Starlight architectural patterns
+- keep author burden low and avoid large new frontmatter requirements unless strongly justified
+- keep metadata logic centralized and easy to reason about
+- make route and metadata behavior testable with repo-local tests and `pnpm build`
+- prefer explicit rules over heuristic-heavy inference
+
+## Options Considered
+
+### Option A - Recommended: Technical SEO foundation first
+
+Focus this PRD on index hygiene, metadata centralization, schema defaults, route stability, internal discovery, and
+guardrails.
+
+Pros:
+
+- clear implementation boundary
+- high leverage for future SEO work
+- avoids mixing infrastructure and editorial rewrites
+- supports future content expansion without rebuilding technical layer twice
+
+Cons:
+
+- some thin pages may still need later content work after technical foundation lands
+- immediate ranking gains may be more modest than a combined technical-plus-editorial project
+
+### Option B - Technical foundation plus top-page remediation
+
+Combine technical work with a rewrite of a small number of the weakest published pages.
+
+Pros:
+
+- faster visible improvements on a few important pages
+- can remove worst thin-page examples immediately
+
+Cons:
+
+- mixes platform and editorial scope
+- can obscure which work belongs in reusable SEO foundation versus page-specific content work
+
+### Option C - Full SEO program
+
+Include technical foundation, keyword mapping, content briefs, refresh workflows, and measurement.
+
+Pros:
+
+- comprehensive long-term strategy
+
+Cons:
+
+- too broad for a single spec-to-plan-to-build cycle
+- higher risk of slow execution and muddled priorities
+
+## Chosen Approach
+
+Use Option A.
+
+The site should first become technically search-ready by default. Once that foundation exists, a follow-on PRD can
+target high-value content expansion and page-quality improvements.
+
+## Proposed Solution Shape
+
+### Layer 1: SEO policy layer
+
+Introduce an explicit concept of search readiness.
+
+This layer determines whether a page is:
+
+- indexable
+- `noindex`
+- excluded from the sitemap until it meets readiness requirements
+
+This should prevent low-value pages from entering search inventory simply because they compile.
+
+### Layer 2: Shared metadata layer
+
+Centralize metadata generation in one shared path.
+
+This layer should:
+
+- reuse current title logic
+- extend it to descriptions, canonical URLs, robots directives, Open Graph tags, Twitter tags, and default preview
+  images
+- keep fallback behavior explicit and safe
+
+### Layer 3: Structured data layer
+
+Add schema output where page context is trustworthy.
+
+This should begin with:
+
+- organization schema on homepage
+- website schema on homepage
+- breadcrumb schema on docs pages with known breadcrumb context
+
+### Layer 4: Discovery layer
+
+Align live navigation and internal links with canonical published content.
+
+This layer should:
+
+- keep important section roots stable
+- expose important published sections through navigation or other meaningful internal linking paths
+- reduce mismatch between what is indexed and what users can easily discover
+
+### Layer 5: Guardrail layer
+
+Add tests and build-time assertions for SEO-critical invariants.
+
+These checks should make SEO regressions visible during routine development instead of after deploy.
+
+## Delivery Phases
+
+### Phase 1: Index hygiene and route regression safety
+
+- define indexable versus `noindex` page rules
+- keep placeholder and thin pages out of search path until ready
+- add regression coverage for valid section roots such as `/3rdparty/`
+- confirm sitemap and index policy stay aligned
+
+### Phase 2: Metadata platform
+
+- centralize title, description, canonical, robots, Open Graph, Twitter, and default preview image logic
+- preserve safe fallback behavior for routes with partial context
+
+### Phase 3: Schema and internal discovery
+
+- add homepage organization and website schema
+- add breadcrumb schema for docs pages with valid context
+- improve internal exposure of important published sections and pages
+
+### Phase 4: Guardrails
+
+- add build and test checks for metadata completeness, index readiness, sitemap rules, and route stability
+
+## Risks and Mitigations
+
+### Risk: Over-broad `noindex` rules hide pages that should rank
+
+Mitigation:
+
+- start with explicit narrow rules
+- target known placeholder and thin-page patterns first
+- verify representative routes in tests
+
+### Risk: Schema emitted with incomplete or wrong context
+
+Mitigation:
+
+- emit schema only when all required fields are available
+- keep schema types limited in this phase
+- validate rendered output during verification
+
+### Risk: Metadata refactor diverges from Starlight behavior
+
+Mitigation:
+
+- preserve Starlight defaults as fallback
+- scope override carefully to SEO-relevant tags
+- keep logic centralized and covered by tests
+
+### Risk: Guardrails are too strict for work-in-progress docs workflow
+
+Mitigation:
+
+- separate “buildable” from “search-ready”
+- permit WIP content to exist while preventing accidental indexation
+- keep rules explicit so contributors understand how to satisfy them
+
+### Risk: Section-root behavior breaks again after file moves or renames
+
+Mitigation:
+
+- add route-level regression coverage for intended public roots
+- treat section-root behavior as product behavior, not incidental filesystem behavior
+
+## Validation Strategy
+
+Implementation should be considered complete only when all of the following are verified:
+
+- `pnpm build` passes
+- representative tests cover homepage, docs page, calculator page, and `noindex` placeholder page
+- rendered output assertions verify title, description, canonical, robots, Open Graph, Twitter, and schema behavior
+- sitemap contains only canonical indexable URLs
+- route regression checks confirm valid section roots such as `/3rdparty/` resolve correctly
+- manual browser spot checks confirm rendered metadata and schema on representative pages
+
+## Implementation Boundary
+
+The implementation plan that follows this spec should cover:
+
+1. defining search-readiness and indexation rules
+2. implementing or extending shared metadata generation
+3. adding default preview-image behavior
+4. adding homepage organization and website schema
+5. adding breadcrumb schema for docs pages with valid context
+6. adding route regression coverage for intended section roots
+7. adding guardrails for empty descriptions, placeholder indexable pages, and sitemap mismatches
+8. verifying output with tests and `pnpm build`
+
+## Follow-On Work
+
+After this foundation lands, the next SEO spec should focus on content quality and page expansion.
+
+That follow-on work can cover:
+
+- rewriting the thinnest published pages
+- improving section introductions
+- keyword mapping and topic clustering
+- expanding high-value pages such as calculators, gear pages, and key docs landing pages
+
+This keeps technical SEO foundation separate from editorial growth work.

--- a/public/social-preview-default.svg
+++ b/public/social-preview-default.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">OpenSimGear social preview</title>
+  <desc id="desc">Default social sharing image for OpenSimGear documentation.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f8fafc" />
+      <stop offset="100%" stop-color="#e2e8f0" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#334155" />
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="630" fill="url(#bg)" rx="36" />
+  <rect x="54" y="54" width="1092" height="522" fill="url(#accent)" rx="28" />
+  <g transform="translate(88 107) scale(3.2)" fill="#f8fafc">
+    <path d="M50.4 78.5a75.1 75.1 0 0 0-28.5 6.9l24.2-65.7c.7-2 1.9-3.2 3.4-3.2h29c1.5 0 2.7 1.2 3.4 3.2l24.2 65.7s-11.6-7-28.5-7L67 45.5c-.4-1.7-1.6-2.8-2.9-2.8-1.3 0-2.5 1.1-2.9 2.7L50.4 78.5Zm-1.1 28.2Zm-4.2-20.2c-2 6.6-.6 15.8 4.2 20.2a17.5 17.5 0 0 1 .2-.7 5.5 5.5 0 0 1 5.7-4.5c2.8.1 4.3 1.5 4.7 4.7.2 1.1.2 2.3.2 3.5v.4c0 2.7.7 5.2 2.2 7.4a13 13 0 0 0 5.7 4.9v-.3l-.2-.3c-1.8-5.6-.5-9.5 4.4-12.8l1.5-1a73 73 0 0 0 3.2-2.2 16 16 0 0 0 6.8-11.4c.3-2 .1-4-.6-6l-.8.6-1.6 1a37 37 0 0 1-22.4 2.7c-5-.7-9.7-2-13.2-6.2Z" />
+  </g>
+  <text x="340" y="234" fill="#f8fafc" font-family="Georgia, 'Times New Roman', serif" font-size="84" font-weight="700" letter-spacing="-2">OpenSimGear</text>
+  <text x="340" y="320" fill="#cbd5e1" font-family="'Trebuchet MS', Arial, sans-serif" font-size="34">Open-source simulation hardware docs, tools, and community builds.</text>
+  <text x="340" y="382" fill="#94a3b8" font-family="'Trebuchet MS', Arial, sans-serif" font-size="28">opensimgear.org</text>
+  <circle cx="1044" cy="142" r="72" fill="#f8fafc" fill-opacity="0.08" />
+  <circle cx="1092" cy="206" r="28" fill="#f8fafc" fill-opacity="0.16" />
+  <circle cx="1014" cy="470" r="96" fill="#f8fafc" fill-opacity="0.06" />
+</svg>

--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -1,17 +1,53 @@
 ---
 import Default from '@astrojs/starlight/components/Head.astro';
+
 import GoogleAnalytics from '~/components/util/GoogleAnalytics.astro';
 import { buildSeoPageTitle, replaceSeoTitleTags } from '~/utils/page-title';
+import { applySeoMetadata } from '~/utils/seo-meta';
+import { buildDefaultSocialImageUrl, getSeoPolicy } from '~/utils/seo-policy';
+import { buildDocBreadcrumbItems } from '~/utils/breadcrumbs';
+import {
+  buildBreadcrumbSchema,
+  buildSiteSchemas,
+} from '~/utils/structured-data';
+import { config } from '~/config';
 
 const { starlightRoute } = Astro.locals;
+const pathname = Astro.url.pathname;
+const isHomepage = pathname === '/';
 const seoTitle = buildSeoPageTitle({
   pageTitle: starlightRoute.entry.data.title,
   siteTitle: starlightRoute.siteTitle,
-  pathname: Astro.url.pathname,
+  pathname,
   sidebar: starlightRoute.sidebar,
 });
-starlightRoute.head = replaceSeoTitleTags(starlightRoute.head, seoTitle);
+const description = starlightRoute.entry.data.description ?? '';
+const seoPolicy = getSeoPolicy(pathname);
+const siteSchemas = isHomepage ? buildSiteSchemas({ site: config.site, title: starlightRoute.siteTitle }) : [];
+const breadcrumbItems = isHomepage
+  ? []
+  : buildDocBreadcrumbItems({
+      sidebar: starlightRoute.sidebar,
+      pathname,
+      currentTitle: starlightRoute.entry.data.title,
+    });
+const breadcrumbSchema = breadcrumbItems.length > 0
+  ? buildBreadcrumbSchema({
+    site: config.site,
+    items: breadcrumbItems,
+  })
+  : undefined;
+
+starlightRoute.head = applySeoMetadata(replaceSeoTitleTags(starlightRoute.head, seoTitle), {
+  pathname,
+  siteUrl: config.site,
+  description,
+  seoPolicy,
+  defaultSocialImageUrl: buildDefaultSocialImageUrl(config.site),
+});
 ---
 
 <Default {...Astro.props}><slot /></Default>
+{siteSchemas.map((schema) => <script type="application/ld+json" is:inline set:html={schema} />)}
+{breadcrumbSchema && <script type="application/ld+json" is:inline set:html={breadcrumbSchema} />}
 {import.meta.env.PROD && <GoogleAnalytics />}

--- a/src/content/docs/3rdparty/index.md
+++ b/src/content/docs/3rdparty/index.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description:
+description: 
   Community-sourced third-party sim racing and flight simulation hardware solutions. Discover open-source belt
   tensioners, G-seat actuators, and motion platform components compatible with OpenSimGear.
 sidebar:

--- a/src/tests/docs/breadcrumbs.test.ts
+++ b/src/tests/docs/breadcrumbs.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildDocBreadcrumbItems } from '../../utils/breadcrumbs';
+
+describe('buildDocBreadcrumbItems', () => {
+  it('keeps only real ancestor breadcrumb links', () => {
+    const items = buildDocBreadcrumbItems({
+      pathname: '/docs/components/buttons/',
+      currentTitle: 'Buttons',
+      sidebar: [
+        {
+          type: 'group',
+          label: 'Docs',
+          entries: [
+            { type: 'link', label: 'Sim Racing', href: '/docs/sim-racing/' },
+            {
+              type: 'group',
+              label: 'Components',
+              entries: [
+                { type: 'link', label: 'Overview', href: '/docs/components/' },
+                { type: 'link', label: 'Buttons', href: '/docs/components/buttons/' },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(items).toEqual([
+      { name: 'Home', item: '/' },
+      { name: 'Components', item: '/docs/components/' },
+      { name: 'Buttons', item: '/docs/components/buttons/' },
+    ]);
+  });
+
+  it('uses current group path without leaking unrelated parent hrefs', () => {
+    const items = buildDocBreadcrumbItems({
+      pathname: '/docs/components/',
+      currentTitle: 'Overview',
+      sidebar: [
+        {
+          type: 'group',
+          label: 'Docs',
+          entries: [
+            { type: 'link', label: 'Sim Racing', href: '/docs/sim-racing/' },
+            {
+              type: 'group',
+              label: 'Components',
+              entries: [
+                { type: 'link', label: 'Overview', href: '/docs/components/' },
+                { type: 'link', label: 'Buttons', href: '/docs/components/buttons/' },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(items).toEqual([
+      { name: 'Home', item: '/' },
+      { name: 'Components', item: '/docs/components/' },
+    ]);
+  });
+});

--- a/src/tests/docs/seo-guardrails.test.ts
+++ b/src/tests/docs/seo-guardrails.test.ts
@@ -1,0 +1,101 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { parseDocFrontmatter } from '../../utils/docs-frontmatter';
+import { getSeoPolicy } from '../../utils/seo-policy';
+
+const docsRoot = path.resolve('src/content/docs');
+
+function collectDocFiles(root: string): string[] {
+  const entries = fs.readdirSync(root, { withFileTypes: true });
+
+  return entries.flatMap((entry) => {
+    const fullPath = path.join(root, entry.name);
+
+    if (entry.isDirectory()) {
+      return collectDocFiles(fullPath);
+    }
+
+    return /\.mdx?$/.test(entry.name) ? [fullPath] : [];
+  });
+}
+
+function createTempDocFile(source: string) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'seo-guardrails-'));
+  const filePath = path.join(tempDir, 'src/content/docs/example.mdx');
+
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, source, 'utf8');
+
+  return filePath;
+}
+
+describe('docs SEO guardrails', () => {
+  it('parses frontmatter with BOM and CRLF line endings', () => {
+    const filePath = createTempDocFile(
+      '\ufeff---\r\ntitle: Example\r\ndescription: Example description\r\n---\r\n\r\nBody copy\r\n'
+    );
+
+    expect(parseDocFrontmatter(filePath)).toMatchObject({
+      pathname: '/example/',
+      frontmatter: 'title: Example\r\ndescription: Example description',
+      title: 'Example',
+      description: 'Example description',
+    });
+    expect(parseDocFrontmatter(filePath).body).toContain('Body copy');
+  });
+
+  it('parses description with inline value plus continued indented lines', () => {
+    const filePath = createTempDocFile(`---
+title: Example
+description: First sentence.
+  Second sentence.
+  Third sentence.
+sidebar:
+  hidden: true
+---
+`);
+
+    expect(parseDocFrontmatter(filePath).description).toBe('First sentence. Second sentence. Third sentence.');
+  });
+
+  it('parses multiline descriptions without swallowing sibling frontmatter keys', () => {
+    expect(parseDocFrontmatter(path.join(docsRoot, '3rdparty/index.md')).description).toBe(
+      'Community-sourced third-party sim racing and flight simulation hardware solutions. Discover open-source belt tensioners, G-seat actuators, and motion platform components compatible with OpenSimGear.'
+    );
+    expect(parseDocFrontmatter(path.join(docsRoot, '3rdparty/belt-tensioner/index.md')).description).toBe('Hidden');
+  });
+
+  it('requires non-empty descriptions for indexable pages', () => {
+    const failures = collectDocFiles(docsRoot)
+      .map(parseDocFrontmatter)
+      .filter(({ pathname }) => getSeoPolicy(pathname).index)
+      .filter(({ description }) => description.trim().length === 0)
+      .map(({ pathname }) => pathname);
+
+    expect(failures).toEqual([]);
+  });
+
+  it('blocks placeholder copy on indexable pages', () => {
+    const failures = collectDocFiles(docsRoot)
+      .map(parseDocFrontmatter)
+      .filter(({ pathname }) => getSeoPolicy(pathname).index)
+      .filter(({ description, body }) => /coming soon/i.test(description) || /coming soon/i.test(body))
+      .map(({ pathname }) => pathname);
+
+    expect(failures).toEqual([]);
+  });
+
+  it('blocks placeholder metadata on indexable pages', () => {
+    const failures = collectDocFiles(docsRoot)
+      .map(parseDocFrontmatter)
+      .filter(({ pathname }) => getSeoPolicy(pathname).index)
+      .filter(({ title, description }) => /^(hidden)$/i.test(title.trim()) || /^(hidden)$/i.test(description.trim()))
+      .map(({ pathname }) => pathname);
+
+    expect(failures).toEqual([]);
+  });
+});

--- a/src/tests/docs/seo-meta.test.ts
+++ b/src/tests/docs/seo-meta.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import type { StarlightRouteData } from '@astrojs/starlight/route-data';
+
+import { applySeoMetadata } from '../../utils/seo-meta';
+
+type HeadConfig = StarlightRouteData['head'];
+
+describe('applySeoMetadata', () => {
+  it('adds canonical and default indexable metadata for docs pages', () => {
+    const head: HeadConfig = [{ tag: 'title', content: 'Components | OpenSimGear' }];
+    const result = applySeoMetadata(head, {
+      pathname: '/docs/components/',
+      siteUrl: 'https://www.opensimgear.org',
+      description: 'Reusable OpenSimGear UI components.',
+      seoPolicy: { index: true, follow: true },
+      defaultSocialImageUrl: 'https://www.opensimgear.org/social-preview-default.svg',
+    });
+
+    expect(result).toContainEqual({
+      tag: 'link',
+      attrs: { rel: 'canonical', href: 'https://www.opensimgear.org/docs/components/' },
+    });
+    expect(result).toContainEqual({
+      tag: 'meta',
+      attrs: { name: 'robots', content: 'index, follow' },
+    });
+    expect(result).toContainEqual({
+      tag: 'meta',
+      attrs: { property: 'og:image', content: 'https://www.opensimgear.org/social-preview-default.svg' },
+    });
+    expect(result).toContainEqual({
+      tag: 'meta',
+      attrs: { property: 'og:url', content: 'https://www.opensimgear.org/docs/components/' },
+    });
+    expect(result).toContainEqual({
+      tag: 'meta',
+      attrs: { name: 'twitter:card', content: 'summary_large_image' },
+    });
+    expect(result).toContainEqual({
+      tag: 'meta',
+      attrs: { name: 'twitter:image', content: 'https://www.opensimgear.org/social-preview-default.svg' },
+    });
+  });
+
+  it('writes noindex robots metadata for gear pages', () => {
+    expect(
+      applySeoMetadata([], {
+        pathname: '/gear/',
+        siteUrl: 'https://www.opensimgear.org',
+        description: '',
+        seoPolicy: { index: false, follow: true },
+        defaultSocialImageUrl: 'https://www.opensimgear.org/social-preview-default.svg',
+      })
+    ).toContainEqual({
+      tag: 'meta',
+      attrs: { name: 'robots', content: 'noindex, follow' },
+    });
+  });
+});

--- a/src/tests/docs/seo-policy.test.ts
+++ b/src/tests/docs/seo-policy.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildCanonicalUrl,
+  buildDefaultSocialImageUrl,
+  getSeoPolicy,
+  shouldIncludeInSitemap,
+} from '../../utils/seo-policy';
+
+describe('getSeoPolicy', () => {
+  it('marks placeholder gear pages as noindex, follow', () => {
+    expect(getSeoPolicy('/gear/')).toEqual({ index: false, follow: true });
+    expect(getSeoPolicy('/gear/hand-brake/')).toEqual({ index: false, follow: true });
+  });
+
+  it('marks hidden third-party landing pages as noindex, follow', () => {
+    expect(getSeoPolicy('/3rdparty/belt-tensioner/')).toEqual({ index: false, follow: true });
+  });
+
+  it('keeps docs pages indexable by default', () => {
+    expect(getSeoPolicy('/docs/components/')).toEqual({ index: true, follow: true });
+  });
+});
+
+describe('shouldIncludeInSitemap', () => {
+  it('excludes noindex pages from sitemap output', () => {
+    expect(shouldIncludeInSitemap('/gear/')).toBe(false);
+    expect(shouldIncludeInSitemap('/gear/hand-brake/')).toBe(false);
+    expect(shouldIncludeInSitemap('/3rdparty/belt-tensioner/')).toBe(false);
+  });
+
+  it('keeps indexable pages in sitemap output', () => {
+    expect(shouldIncludeInSitemap('/docs/components/')).toBe(true);
+  });
+});
+
+describe('buildCanonicalUrl', () => {
+  it('joins site url and pathname into canonical url', () => {
+    expect(buildCanonicalUrl('https://www.opensimgear.org', '/3rdparty/')).toBe(
+      'https://www.opensimgear.org/3rdparty/'
+    );
+  });
+});
+
+describe('buildDefaultSocialImageUrl', () => {
+  it('builds default social image url from site url', () => {
+    expect(buildDefaultSocialImageUrl('https://www.opensimgear.org')).toBe(
+      'https://www.opensimgear.org/social-preview-default.svg'
+    );
+  });
+
+  it('ships default social preview asset', () => {
+    const asset = readFileSync(new URL('../../../public/social-preview-default.svg', import.meta.url), 'utf8');
+
+    expect(asset).toContain('<svg');
+    expect(asset).toContain('width="1200"');
+    expect(asset).toContain('height="630"');
+    expect(asset).toContain('viewBox="0 0 1200 630"');
+    expect(asset).toContain('<title id="title">OpenSimGear social preview</title>');
+    expect(asset).toContain('>OpenSimGear</text>');
+    expect(asset).toContain('>opensimgear.org</text>');
+  });
+});

--- a/src/tests/docs/sidebar-config.test.ts
+++ b/src/tests/docs/sidebar-config.test.ts
@@ -245,7 +245,7 @@ sidebar:
 
     expect(sidebar).toContainEqual({
       label: 'Overview',
-      link: '/3rdparty/overview/',
+      link: '/3rdparty/',
     });
 
     const beltTensionerGroup = sidebar.find((item) => item.label === 'Belt Tensioner');
@@ -261,6 +261,31 @@ sidebar:
     expect(beltTensionerGroup.items).not.toContainEqual({
       label: 'Flag Ghost Belt Tensioner',
       link: '/docs/belt-tensioner/flagghost/',
+    });
+  });
+
+  it('maps a top-level index file to the base path root', () => {
+    const fixtureRoot = createDocsFixture({
+      'index.md': `---
+title: Overview
+sidebar:
+  order: 0
+---
+`,
+      'belt-tensioner/index.md': `---
+title: Belt Tensioner Overview
+sidebar:
+  label: Belt Tensioner
+  order: 1
+---
+`,
+    });
+
+    const sidebar = buildDocsSidebar({ docsRoot: fixtureRoot, basePath: '/3rdparty' });
+
+    expect(sidebar).toContainEqual({
+      label: 'Overview',
+      link: '/3rdparty/',
     });
   });
 });

--- a/src/tests/docs/structured-data.test.ts
+++ b/src/tests/docs/structured-data.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildBreadcrumbSchema, buildSiteSchemas } from '../../utils/structured-data';
+
+describe('buildSiteSchemas', () => {
+  it('returns organization and website JSON-LD strings for homepage metadata', () => {
+    const schemas = buildSiteSchemas({
+      site: 'https://www.opensimgear.org',
+      title: 'OpenSimGear',
+    });
+
+    const [organizationSchema, websiteSchema] = schemas.map((schema) => JSON.parse(schema));
+
+    expect(schemas).toHaveLength(2);
+    expect(organizationSchema['@type']).toBe('Organization');
+    expect(organizationSchema.name).toBe('OpenSimGear');
+    expect(organizationSchema.url).toBe('https://www.opensimgear.org/');
+    expect(websiteSchema['@type']).toBe('WebSite');
+    expect(websiteSchema.name).toBe('OpenSimGear');
+    expect(websiteSchema.url).toBe('https://www.opensimgear.org/');
+  });
+});
+
+describe('buildBreadcrumbSchema', () => {
+  it('returns breadcrumb list JSON-LD string for docs pages', () => {
+    const schema = JSON.parse(
+      buildBreadcrumbSchema({
+        site: 'https://www.opensimgear.org',
+        items: [
+          { name: 'Home', item: '/' },
+          { name: 'Docs', item: '/docs' },
+          { name: 'Components', item: '/docs/components/' },
+          { name: 'Buttons', item: '/docs/components/buttons/' },
+        ],
+      })
+    );
+
+    expect(schema['@type']).toBe('BreadcrumbList');
+    expect(schema.itemListElement).toEqual([
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Home',
+        item: 'https://www.opensimgear.org/',
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: 'Docs',
+        item: 'https://www.opensimgear.org/docs/',
+      },
+      {
+        '@type': 'ListItem',
+        position: 3,
+        name: 'Components',
+        item: 'https://www.opensimgear.org/docs/components/',
+      },
+      {
+        '@type': 'ListItem',
+        position: 4,
+        name: 'Buttons',
+        item: 'https://www.opensimgear.org/docs/components/buttons/',
+      },
+    ]);
+  });
+
+  it('normalizes breadcrumb item paths before building absolute URLs', () => {
+    const schema = JSON.parse(
+      buildBreadcrumbSchema({
+        site: 'https://www.opensimgear.org',
+        items: [
+          { name: 'Home', item: '/' },
+          { name: 'Docs', item: '/docs?ref=nav#top' },
+          { name: 'Buttons', item: '/docs/components/buttons?tab=seo' },
+        ],
+      })
+    );
+
+    expect(schema.itemListElement).toEqual([
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Home',
+        item: 'https://www.opensimgear.org/',
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: 'Docs',
+        item: 'https://www.opensimgear.org/docs/',
+      },
+      {
+        '@type': 'ListItem',
+        position: 3,
+        name: 'Buttons',
+        item: 'https://www.opensimgear.org/docs/components/buttons/',
+      },
+    ]);
+  });
+});

--- a/src/utils/breadcrumbs.ts
+++ b/src/utils/breadcrumbs.ts
@@ -1,0 +1,142 @@
+import { normalizeStructuredDataPath, type BreadcrumbItem } from './structured-data';
+
+export type BreadcrumbSidebarEntry = BreadcrumbSidebarLink | BreadcrumbSidebarGroup;
+
+type BreadcrumbSidebarLink = {
+  type: 'link';
+  label: string;
+  href: string;
+};
+
+type BreadcrumbSidebarGroup = {
+  type: 'group';
+  label: string;
+  entries: BreadcrumbSidebarEntry[];
+};
+
+type BuildDocBreadcrumbItemsOptions = {
+  sidebar: BreadcrumbSidebarEntry[];
+  pathname: string;
+  currentTitle: string;
+};
+
+function normalizeComparablePath(pathname: string) {
+  return normalizeStructuredDataPath(pathname).slice(0, -1);
+}
+
+function findFirstLinkHref(entries: BreadcrumbSidebarEntry[]): string | undefined {
+  for (const entry of entries) {
+    if (entry.type === 'link') {
+      return entry.href;
+    }
+
+    const href = findFirstLinkHref(entry.entries);
+
+    if (href) {
+      return href;
+    }
+  }
+
+  return undefined;
+}
+
+function isRealAncestorPath(ancestorHref: string, pathname: string) {
+  const normalizedAncestor = normalizeComparablePath(ancestorHref);
+  const normalizedPathname = normalizeComparablePath(pathname);
+
+  return (
+    normalizedAncestor.length > 0 &&
+    normalizedAncestor !== normalizedPathname &&
+    normalizedPathname.startsWith(`${normalizedAncestor}/`)
+  );
+}
+
+function buildParentBreadcrumbItems(parents: BreadcrumbSidebarGroup[], pathname: string): BreadcrumbItem[] {
+  return parents.flatMap((parent) => {
+    const href = findFirstLinkHref(parent.entries);
+
+    return href && isRealAncestorPath(href, pathname) ? [{ name: parent.label, item: href }] : [];
+  });
+}
+
+function findBreadcrumbItems(
+  entries: BreadcrumbSidebarEntry[],
+  pathname: string,
+  currentTitle: string,
+  parents: BreadcrumbSidebarGroup[] = []
+): BreadcrumbItem[] | undefined {
+  const normalizedPathname = normalizeComparablePath(pathname);
+
+  for (const entry of entries) {
+    if (entry.type === 'link' && normalizeComparablePath(entry.href) === normalizedPathname) {
+      const currentItemName =
+        (currentTitle === 'Hidden' || currentTitle === 'Overview') && parents.at(-1)
+          ? parents.at(-1)!.label
+          : entry.label;
+
+      return [
+        { name: 'Home', item: '/' },
+        ...buildParentBreadcrumbItems(parents, pathname),
+        { name: currentItemName, item: entry.href },
+      ];
+    }
+
+    if (entry.type === 'group') {
+      const match = findBreadcrumbItems(entry.entries, pathname, currentTitle, [...parents, entry]);
+
+      if (match) {
+        return match;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function findGroupBreadcrumbItems(
+  entries: BreadcrumbSidebarEntry[],
+  pathname: string,
+  currentTitle: string,
+  parents: BreadcrumbSidebarGroup[] = []
+): BreadcrumbItem[] | undefined {
+  const normalizedPathname = normalizeComparablePath(pathname);
+
+  for (const entry of entries) {
+    if (entry.type !== 'group') {
+      continue;
+    }
+
+    const nextParents = [...parents, entry];
+
+    for (const child of entry.entries) {
+      if (child.type === 'link' && normalizeComparablePath(child.href).startsWith(`${normalizedPathname}/`)) {
+        return [
+          { name: 'Home', item: '/' },
+          ...buildParentBreadcrumbItems(parents, pathname),
+          {
+            name: currentTitle === 'Hidden' || currentTitle === 'Overview' ? entry.label : currentTitle,
+            item: pathname,
+          },
+        ];
+      }
+    }
+
+    const nestedMatch = findGroupBreadcrumbItems(entry.entries, pathname, currentTitle, nextParents);
+
+    if (nestedMatch) {
+      return nestedMatch;
+    }
+  }
+
+  return undefined;
+}
+
+export function buildDocBreadcrumbItems({ sidebar, pathname, currentTitle }: BuildDocBreadcrumbItemsOptions) {
+  return (
+    findBreadcrumbItems(sidebar, pathname, currentTitle) ??
+    findGroupBreadcrumbItems(sidebar, pathname, currentTitle) ?? [
+      { name: 'Home', item: '/' },
+      { name: currentTitle, item: pathname },
+    ]
+  );
+}

--- a/src/utils/docs-frontmatter.ts
+++ b/src/utils/docs-frontmatter.ts
@@ -1,0 +1,89 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DOCS_ROOT = path.resolve('src/content/docs');
+const DOCS_ROOT_SEGMENT = 'src/content/docs/';
+
+export type ParsedDocFrontmatter = {
+  filePath: string;
+  pathname: string;
+  frontmatter: string;
+  title: string;
+  description: string;
+  body: string;
+};
+
+export function parseDocFrontmatter(filePath: string): ParsedDocFrontmatter {
+  const source = fs.readFileSync(filePath, 'utf8');
+  const match = source.match(/^\ufeff?---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  const frontmatter = match?.[1] ?? '';
+  const body = source.slice(match?.[0].length ?? 0);
+
+  return {
+    filePath,
+    pathname: toDocPathname(filePath),
+    frontmatter,
+    title: readFrontmatterValue(frontmatter, 'title'),
+    description: readFrontmatterValue(frontmatter, 'description'),
+    body,
+  };
+}
+
+function toDocPathname(filePath: string) {
+  const normalizedFilePath = filePath.split(path.sep).join('/');
+  const docsRootIndex = normalizedFilePath.lastIndexOf(DOCS_ROOT_SEGMENT);
+  const relativePath =
+    docsRootIndex >= 0
+      ? normalizedFilePath.slice(docsRootIndex + DOCS_ROOT_SEGMENT.length)
+      : path.relative(DOCS_ROOT, filePath).split(path.sep).join('/');
+  const withoutExtension = relativePath.replace(/\.mdx?$/, '');
+  const slug = withoutExtension === 'index' ? '' : withoutExtension.replace(/\/index$/, '');
+
+  return slug ? `/${slug}/` : '/';
+}
+
+function readFrontmatterValue(frontmatter: string, key: string) {
+  const lines = frontmatter.split(/\r?\n/);
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = lines[index].match(new RegExp(`^${key}:\\s*(.*)$`));
+
+    if (!match) {
+      continue;
+    }
+
+    const value = match[1].trim();
+    const parts = value && !isBlockIndicator(value) ? [stripQuotes(value)] : [];
+
+    if (parts.length === 1 && !hasIndentedContinuation(lines, index + 1)) {
+      return parts[0];
+    }
+
+    let blockIndex = index + 1;
+
+    while (blockIndex < lines.length && /^[ \t]+/.test(lines[blockIndex])) {
+      parts.push(lines[blockIndex].replace(/^[ \t]+/, '').trim());
+      blockIndex += 1;
+    }
+
+    return isLiteralBlockIndicator(value) ? parts.join('\n').trim() : parts.join(' ').trim();
+  }
+
+  return '';
+}
+
+function hasIndentedContinuation(lines: string[], index: number) {
+  return index < lines.length && /^[ \t]+/.test(lines[index]);
+}
+
+function isBlockIndicator(value: string) {
+  return value === '' || value === '>' || value === '>-' || value === '|' || value === '|-';
+}
+
+function isLiteralBlockIndicator(value: string) {
+  return value === '|' || value === '|-';
+}
+
+function stripQuotes(value: string) {
+  return value.replace(/^['"]|['"]$/g, '');
+}

--- a/src/utils/seo-meta.ts
+++ b/src/utils/seo-meta.ts
@@ -1,0 +1,75 @@
+import type { StarlightRouteData } from '@astrojs/starlight/route-data';
+
+import { buildCanonicalUrl, type SeoPolicy } from './seo-policy';
+
+type HeadEntry = StarlightRouteData['head'][number];
+type HeadConfig = StarlightRouteData['head'];
+
+type ApplySeoMetadataOptions = {
+  pathname: string;
+  siteUrl: string;
+  description: string;
+  seoPolicy: SeoPolicy;
+  defaultSocialImageUrl: string;
+};
+
+function upsertLink(head: HeadConfig, rel: string, href: string): HeadConfig {
+  const index = head.findIndex((entry) => entry.tag === 'link' && entry.attrs?.rel === rel);
+  const nextEntry: HeadEntry = {
+    tag: 'link',
+    attrs: { rel, href },
+  };
+
+  if (index === -1) {
+    return [...head, nextEntry];
+  }
+
+  return head.map((entry, entryIndex) => (entryIndex === index ? nextEntry : entry));
+}
+
+function upsertMetaByName(head: HeadConfig, name: string, content: string): HeadConfig {
+  const index = head.findIndex((entry) => entry.tag === 'meta' && entry.attrs?.name === name);
+  const nextEntry: HeadEntry = {
+    tag: 'meta',
+    attrs: { name, content },
+  };
+
+  if (index === -1) {
+    return [...head, nextEntry];
+  }
+
+  return head.map((entry, entryIndex) => (entryIndex === index ? nextEntry : entry));
+}
+
+function upsertMetaByProperty(head: HeadConfig, property: string, content: string): HeadConfig {
+  const index = head.findIndex((entry) => entry.tag === 'meta' && entry.attrs?.property === property);
+  const nextEntry: HeadEntry = {
+    tag: 'meta',
+    attrs: { property, content },
+  };
+
+  if (index === -1) {
+    return [...head, nextEntry];
+  }
+
+  return head.map((entry, entryIndex) => (entryIndex === index ? nextEntry : entry));
+}
+
+export function applySeoMetadata(head: HeadConfig, options: ApplySeoMetadataOptions): HeadConfig {
+  const { pathname, siteUrl, description, seoPolicy, defaultSocialImageUrl } = options;
+  const robots = `${seoPolicy.index ? 'index' : 'noindex'}, ${seoPolicy.follow ? 'follow' : 'nofollow'}`;
+  const canonicalUrl = buildCanonicalUrl(siteUrl, pathname);
+
+  let nextHead = upsertLink(head, 'canonical', canonicalUrl);
+
+  nextHead = upsertMetaByName(nextHead, 'description', description);
+  nextHead = upsertMetaByName(nextHead, 'robots', robots);
+  nextHead = upsertMetaByProperty(nextHead, 'og:description', description);
+  nextHead = upsertMetaByProperty(nextHead, 'og:image', defaultSocialImageUrl);
+  nextHead = upsertMetaByProperty(nextHead, 'og:url', canonicalUrl);
+  nextHead = upsertMetaByName(nextHead, 'twitter:card', 'summary_large_image');
+  nextHead = upsertMetaByName(nextHead, 'twitter:description', description);
+  nextHead = upsertMetaByName(nextHead, 'twitter:image', defaultSocialImageUrl);
+
+  return nextHead;
+}

--- a/src/utils/seo-policy.ts
+++ b/src/utils/seo-policy.ts
@@ -1,0 +1,37 @@
+export type SeoPolicy = {
+  index: boolean;
+  follow: boolean;
+};
+
+const NOINDEX_PATHS_LIST = ['/gear', '/gear/hand-brake', '/3rdparty/belt-tensioner'] as const;
+
+const NOINDEX_PATHS = new Set<string>(NOINDEX_PATHS_LIST);
+
+function normalizePathname(pathname: string) {
+  const [path] = pathname.split(/[?#]/, 1);
+
+  if (!path || path === '/') {
+    return '/';
+  }
+
+  return path.endsWith('/') ? path.slice(0, -1) : path;
+}
+
+export function getSeoPolicy(pathname: string): SeoPolicy {
+  return {
+    index: !NOINDEX_PATHS.has(normalizePathname(pathname)),
+    follow: true,
+  };
+}
+
+export function shouldIncludeInSitemap(pathname: string) {
+  return getSeoPolicy(pathname).index;
+}
+
+export function buildCanonicalUrl(siteUrl: string, pathname: string) {
+  return new URL(pathname, siteUrl).toString();
+}
+
+export function buildDefaultSocialImageUrl(siteUrl: string) {
+  return buildCanonicalUrl(siteUrl, '/social-preview-default.svg');
+}

--- a/src/utils/structured-data.ts
+++ b/src/utils/structured-data.ts
@@ -1,0 +1,62 @@
+type BuildSiteSchemasOptions = {
+  site: string;
+  title: string;
+};
+
+export type BreadcrumbItem = {
+  name: string;
+  item: string;
+};
+
+type BuildBreadcrumbSchemaOptions = {
+  site: string;
+  items: BreadcrumbItem[];
+};
+
+export function normalizeStructuredDataPath(pathname: string) {
+  const [path] = pathname.split(/[?#]/, 1);
+
+  if (!path || path === '/') {
+    return '/';
+  }
+
+  return path.endsWith('/') ? path : `${path}/`;
+}
+
+export function toStructuredDataUrl(site: string, pathname: string) {
+  return new URL(normalizeStructuredDataPath(pathname), site).toString();
+}
+
+function toJsonString(value: unknown) {
+  return JSON.stringify(value);
+}
+
+export function buildSiteSchemas({ site, title }: BuildSiteSchemasOptions) {
+  return [
+    toJsonString({
+      '@context': 'https://schema.org',
+      '@type': 'Organization',
+      name: title,
+      url: toStructuredDataUrl(site, '/'),
+    }),
+    toJsonString({
+      '@context': 'https://schema.org',
+      '@type': 'WebSite',
+      name: title,
+      url: toStructuredDataUrl(site, '/'),
+    }),
+  ];
+}
+
+export function buildBreadcrumbSchema({ site, items }: BuildBreadcrumbSchemaOptions) {
+  return toJsonString({
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((breadcrumbItem, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: breadcrumbItem.name,
+      item: toStructuredDataUrl(site, breadcrumbItem.item),
+    })),
+  });
+}


### PR DESCRIPTION
## Summary
- add a shared technical SEO layer for canonical, robots, OG/Twitter metadata, default social preview images, and JSON-LD output
- exclude noindex routes from the sitemap, harden breadcrumb generation, and make third-party section-root routing regressions testable
- add SEO guardrail tests for placeholder metadata, missing descriptions, and route/indexing regressions

## Test Plan
- [x] `pnpm test src/tests/docs/sidebar-config.test.ts src/tests/docs/page-title.test.ts src/tests/docs/seo-policy.test.ts src/tests/docs/seo-meta.test.ts src/tests/docs/structured-data.test.ts src/tests/docs/seo-guardrails.test.ts src/tests/docs/breadcrumbs.test.ts`
- [x] `pnpm test`
- [x] `pnpm build`